### PR TITLE
Fix PHP 8.4 deprecation warnings

### DIFF
--- a/Plugin/Model/GuestPaymentInformationManagement.php
+++ b/Plugin/Model/GuestPaymentInformationManagement.php
@@ -56,7 +56,7 @@ class GuestPaymentInformationManagement
         $cartId,
         string $email,
         PaymentInterface $paymentMethod,
-        AddressInterface $billingAddress = null
+        ?AddressInterface $billingAddress = null
     ) {
         // phpcs:disable Generic.Files.LineLength
         /* @phpstan-ignore-next-line */

--- a/Plugin/Model/PaymentInformationManagement.php
+++ b/Plugin/Model/PaymentInformationManagement.php
@@ -53,7 +53,7 @@ class PaymentInformationManagement
         \Magento\Checkout\Model\PaymentInformationManagement $subject,
         $cartId,
         PaymentInterface $paymentMethod,
-        AddressInterface $billingAddress = null
+        ?AddressInterface $billingAddress = null
     ) {
         // phpcs:disable Generic.Files.LineLength
         /* @phpstan-ignore-next-line */


### PR DESCRIPTION
Fix PHP 8.4 deprecation warnings by explicitly marking nullable parameters